### PR TITLE
test(recon): add immediate canary assertion + global invariant failures

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -19,6 +19,9 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         targetSender(address(0x10000));
         targetSender(address(0x20000));
         targetSender(address(0x30000));
+
+        // Canary: force one assertion-failure invariant to fail immediately.
+        _recordAssertion(false, ASSERTION_CANARY_ASSERTION_FAILURE);
     }
 
     function _isAssertion(string memory reason) internal pure returns (bool) {
@@ -181,6 +184,16 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
                 ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM
             ],
             ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM
+        );
+    }
+
+    function invariant_assertion_failure_CANARY_ASSERTION_FAILURE()
+        public
+        view
+    {
+        assertTrue(
+            !assertionFailures[ASSERTION_CANARY_ASSERTION_FAILURE],
+            ASSERTION_CANARY_ASSERTION_FAILURE
         );
     }
 

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -19,9 +19,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         targetSender(address(0x10000));
         targetSender(address(0x20000));
         targetSender(address(0x30000));
-
-        // Canary: force one assertion-failure invariant to fail immediately.
-        _recordAssertion(false, ASSERTION_CANARY_ASSERTION_FAILURE);
+        // Canary assertion failures are recorded when the fuzzer exercises canary checks.
     }
 
     function _isAssertion(string memory reason) internal pure returns (bool) {
@@ -187,10 +185,10 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_CANARY_ASSERTION_FAILURE()
+    function invariant_assertion_failure_CANARY()
         public
-        view
     {
+        invariant_canary_assertion_failure();
         assertTrue(
             !assertionFailures[ASSERTION_CANARY_ASSERTION_FAILURE],
             ASSERTION_CANARY_ASSERTION_FAILURE

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -19,7 +19,6 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         targetSender(address(0x10000));
         targetSender(address(0x20000));
         targetSender(address(0x30000));
-        // Canary assertion failures are recorded when the fuzzer exercises canary checks.
     }
 
     function _isAssertion(string memory reason) internal pure returns (bool) {

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -33,9 +33,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     string constant ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM =
         "!!! _update should never revert in transferFrom";
     string constant ASSERTION_CANARY_ASSERTION_FAILURE =
-        "!!! CANARY_ASSERTION_FAILURE";
+        "!!! canary assertion";
     string constant INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE =
-        "CANARY_GLOBAL_INVARIANT_FAILURE";
+        "Canary invariant";
 
     /// @dev Property: oracle PPS doesn't change on deposit/mint/redeem/withdraw
     function property_oraclePPSDoesntChangeOnAddOrRemove() public {
@@ -644,7 +644,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Canary global invariant expected to fail immediately.
-    function invariant_canary_global_invariant_failure() public returns (bool) {
+    function invariant_canary() public returns (bool) {
         t(false, INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE);
         return false;
     }

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -32,6 +32,10 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         "!!! _update should never revert in transfer";
     string constant ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM =
         "!!! _update should never revert in transferFrom";
+    string constant ASSERTION_CANARY_ASSERTION_FAILURE =
+        "!!! CANARY_ASSERTION_FAILURE";
+    string constant INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE =
+        "CANARY_GLOBAL_INVARIANT_FAILURE";
 
     /// @dev Property: oracle PPS doesn't change on deposit/mint/redeem/withdraw
     function property_oraclePPSDoesntChangeOnAddOrRemove() public {
@@ -633,9 +637,17 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
 
     // Canaries
 
-    // function canary_deployedNewVault() public {
-    //     t(!hasDeployedNewVault, "deployed new vault canary");
-    // }
+    /// @dev Canary assertion failure expected to fail immediately.
+    function invariant_canary_assertion_failure() public returns (bool) {
+        t(false, ASSERTION_CANARY_ASSERTION_FAILURE);
+        return false;
+    }
+
+    /// @dev Canary global invariant expected to fail immediately.
+    function invariant_canary_global_invariant_failure() public returns (bool) {
+        t(false, INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE);
+        return false;
+    }
 
     // ERC7540 Properties from erc7540-reusable-properties
 


### PR DESCRIPTION
## Summary
- rename canary globals in `test/recon/Properties.sol`:
  - `invariant_canary_global_invariant_failure` -> `invariant_canary`
  - `ASSERTION_CANARY_ASSERTION_FAILURE` string -> `"!!! canary assertion"`
  - `INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE` string -> `"Canary invariant"`
- update Foundry wrapper in `test/recon/CryticToFoundry.sol`:
  - `invariant_assertion_failure_CANARY_ASSERTION_FAILURE` -> `invariant_assertion_failure_CANARY`
  - remove setup pre-seed `_recordAssertion(false, ASSERTION_CANARY_ASSERTION_FAILURE)`
  - trigger `invariant_canary_assertion_failure()` inside wrapper before asserting the recorded map entry

This keeps canaries intentional/immediate while removing setup hardcoding and ensuring wrapper behavior is deterministic.

## Validation (local smoke, renamed canaries)
- Echidna (`invariant_` canaries):
  - `Test invariant_canary falsified`
  - `Test invariant_canary_assertion_failure falsified`
  - `DURATION_SEC=26.12`
- Medusa:
  - `[FAILED] Property Test: CryticTester.invariant_canary()`
  - `[FAILED] Property Test: CryticTester.invariant_canary_assertion_failure()`
  - `DURATION_SEC=141.31`
- Foundry global canary:
  - `[FAIL ... Canary invariant] invariant_canary()`
  - `DURATION_SEC=21.71`
- Foundry assertion wrapper:
  - `[FAIL ... !!! canary assertion] invariant_assertion_failure_CANARY()`
  - `DURATION_SEC=7.98`

Acceptance met: all fuzzers found at least the 2 canary issues in under 5 minutes.

Related: https://github.com/Recon-Fuzz/scfuzzbench/issues/74
