### PR TITLE
test(recon): switch assertion canary to assert_canary(uint256)

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -186,8 +186,8 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
     function invariant_assertion_failure_CANARY()
         public
+        view
     {
-        invariant_canary_assertion_failure();
         assertTrue(
             !assertionFailures[ASSERTION_CANARY_ASSERTION_FAILURE],
             ASSERTION_CANARY_ASSERTION_FAILURE

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -189,8 +189,8 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         view
     {
         assertTrue(
-            !assertionFailures[ASSERTION_CANARY_ASSERTION_FAILURE],
-            ASSERTION_CANARY_ASSERTION_FAILURE
+            !assertionFailures[ASSERTION_CANARY],
+            ASSERTION_CANARY
         );
     }
 

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -637,10 +637,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
 
     // Canaries
 
-    /// @dev Canary assertion failure expected to fail immediately.
-    function invariant_canary_assertion_failure() public returns (bool) {
-        t(false, ASSERTION_CANARY_ASSERTION_FAILURE);
-        return false;
+    /// @dev Canary assertion helper. A failing input is expected to be discovered during fuzzing.
+    function assert_canary(uint256 entropy) public {
+        t(entropy > 0, ASSERTION_CANARY_ASSERTION_FAILURE);
     }
 
     /// @dev Canary global invariant expected to fail immediately.

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -32,7 +32,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         "!!! _update should never revert in transfer";
     string constant ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM =
         "!!! _update should never revert in transferFrom";
-    string constant ASSERTION_CANARY_ASSERTION_FAILURE =
+    string constant ASSERTION_CANARY =
         "!!! canary assertion";
     string constant INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE =
         "Canary invariant";
@@ -639,7 +639,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
 
     /// @dev Canary assertion helper. A failing input is expected to be discovered during fuzzing.
     function assert_canary(uint256 entropy) public {
-        t(entropy > 0, ASSERTION_CANARY_ASSERTION_FAILURE);
+        t(entropy > 0, ASSERTION_CANARY);
     }
 
     /// @dev Canary global invariant expected to fail immediately.


### PR DESCRIPTION
## Summary
- replace `invariant_canary_assertion_failure()` with:
  - `assert_canary(uint256 entropy)` in `test/recon/Properties.sol`
  - implementation: `t(entropy > 0, ASSERTION_CANARY_ASSERTION_FAILURE)`
- update `test/recon/CryticToFoundry.sol`:
  - keep `invariant_assertion_failure_CANARY` as wrapper-only assertion map check
  - remove direct call to `invariant_canary_assertion_failure()` inside wrapper
- keep inherited `invariant_canary` global canary flow unchanged

## Why
Align canary behavior with the updated pattern:
- assertion canary is triggered by fuzzed action input (`assert_canary(0)`)
- Foundry wrapper only verifies that assertion canary was recorded

## Local Validation
Foundry smoke checks:
- `invariant_canary()` fails with `Canary invariant` (`DURATION_SEC=38.09`)
- `invariant_assertion_failure_CANARY()` fails with `!!! canary assertion` (`DURATION_SEC=48.76`)

Related: https://github.com/Recon-Fuzz/scfuzzbench/issues/74
