### PR TITLE
Recon: complete Foundry assertion compatibility for assertion failures

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -108,6 +108,10 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         assertionFailures[reason] = true;
     }
 
+    function _assertNoAssertionFailure(string memory reason) internal view {
+        assertTrue(!assertionFailures[reason], reason);
+    }
+
     function invariant_assertion_failure_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT()
         public
         view
@@ -182,6 +186,188 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
             ],
             ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM
         );
+    }
+
+    function invariant_assertion_failure_PREVIEW_DEPOSIT_EQUIVALENCE()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE);
+    }
+
+    function invariant_assertion_failure_PREVIEW_MINT_EQUIVALENCE()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_PREVIEW_MINT_EQUIVALENCE);
+    }
+
+    function invariant_assertion_failure_MINT_REDEEM_SYMMETRICAL()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_MINT_REDEEM_SYMMETRICAL);
+    }
+
+    function invariant_assertion_failure_DEPOSIT_WITHDRAW_SYMMETRICAL()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL);
+    }
+
+    function invariant_assertion_failure_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION
+        );
+    }
+
+    function invariant_assertion_failure_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL
+        );
+    }
+
+    function invariant_assertion_failure_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS
+        );
+    }
+
+    function invariant_assertion_failure_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO);
+    }
+
+    function invariant_assertion_failure_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO);
+    }
+
+    function invariant_assertion_failure_CANCEL_REDEEM_NO_OVERPAY()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_NO_OVERPAY);
+    }
+
+    function invariant_assertion_failure_PREVIEW_DEPOSIT_MATCHES_EXECUTION()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION);
+    }
+
+    function invariant_assertion_failure_PREVIEW_MINT_MATCHES_EXECUTION()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION);
+    }
+
+    function invariant_assertion_failure_TRANSFER_SHARES_CONSERVED()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_TRANSFER_SHARES_CONSERVED);
+    }
+
+    function invariant_assertion_failure_TRANSFER_COST_BASIS_CONSERVED()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_TRANSFER_COST_BASIS_CONSERVED);
+    }
+
+    function invariant_assertion_failure_STRATEGY_NO_LOSS_ON_FULFILLMENT()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT);
+    }
+
+    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES()
+        public
+        view
+    {
+        _assertNoAssertionFailure(ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES);
+    }
+
+    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
+        );
+    }
+
+    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS
+        );
+    }
+
+    function invariant_assertion_failure_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS
+        );
+    }
+
+    function invariant_assertion_failure_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT()
+        public
+        view
+    {
+        _assertNoAssertionFailure(
+            ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT
+        );
+    }
+
+    function invariant_assertion_failure_ERC7540_4_DEPOSIT() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_4_DEPOSIT);
+    }
+
+    function invariant_assertion_failure_ERC7540_4_MINT() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_4_MINT);
+    }
+
+    function invariant_assertion_failure_ERC7540_4_WITHDRAW() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_4_WITHDRAW);
+    }
+
+    function invariant_assertion_failure_ERC7540_4_REDEEM() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_4_REDEEM);
+    }
+
+    function invariant_assertion_failure_ERC7540_5() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_5);
+    }
+
+    function invariant_assertion_failure_ERC7540_7_WITHDRAW() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_7_WITHDRAW);
+    }
+
+    function invariant_assertion_failure_ERC7540_7_REDEEM() public view {
+        _assertNoAssertionFailure(ASSERTION_ERC7540_7_REDEEM);
     }
 
     function invariant_assertion_failure_CANARY()

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -22,16 +22,70 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         "!!! redeeming maxRedeem should not revert";
     string constant ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT =
         "!!! withdraw of maxWithdraw should not revert";
+    string constant ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE =
+        "!!! previewDeposit and deposit equivalence";
+    string constant ASSERTION_PREVIEW_MINT_EQUIVALENCE =
+        "!!! previewMint and mint equivalence";
+    string constant ASSERTION_MINT_REDEEM_SYMMETRICAL =
+        "!!! user loses assets in mint/redeem flow";
+    string constant ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL =
+        "!!! user loses assets in deposit/withdraw flow";
+    string constant ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION =
+        "!!! maxRedeem should be reset to 0 after full redemption";
+    string constant ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL =
+        "!!! maxWithdraw should be reset to 0 after full withdrawal";
+    string constant ASSERTION_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS =
+        "!!! total shares redeemed must not exceed sum of requested shares";
     string constant ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE =
         "!!! Primary manager should always be changeable if not paused";
     string constant ASSERTION_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED =
         "!!! users should always be able to withdraw unless the system is paused";
+    string constant ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO =
+        "!!! pendingRedeemRequests should be 0 after cancelling a redemption";
+    string constant ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO =
+        "!!! averageRequestPPS should be 0 after cancelling a redemption";
+    string constant ASSERTION_CANCEL_REDEEM_NO_OVERPAY =
+        "!!! user should not receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem";
+    string constant ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION =
+        "!!! previewDeposit returns the correct amount compared to executing a deposit";
+    string constant ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION =
+        "!!! previewMint returns the correct amount compared to executing a mint";
+    string constant ASSERTION_TRANSFER_SHARES_CONSERVED =
+        "!!! shares are lost on transfer";
+    string constant ASSERTION_TRANSFER_COST_BASIS_CONSERVED =
+        "!!! cost basis is lost on transfer";
     string constant ASSERTION_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM =
         "!!! Claiming redemptions should never revert with INVALID_REDEEM_CLAIM";
     string constant ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER =
         "!!! _update should never revert in transfer";
     string constant ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM =
         "!!! _update should never revert in transferFrom";
+    string constant ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT =
+        "!!! strategy incurs loss on fulfillment";
+    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES =
+        "!!! previewMint and previewDeposit equivalence (from shares)";
+    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS =
+        "!!! previewMint and previewDeposit equivalence under (from assets)";
+    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS =
+        "!!! previewMint and previewDeposit equivalence over (from assets)";
+    string constant ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS =
+        "!!! previewMint is >= convertToAssets";
+    string constant ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT =
+        "!!! convertToShares is >= previewDepositShares (equivalent without fees)";
+    string constant ASSERTION_ERC7540_4_DEPOSIT =
+        "!!! ERC7540-4: deposit with more than max should revert";
+    string constant ASSERTION_ERC7540_4_MINT =
+        "!!! ERC7540-4: mint with more than max should revert";
+    string constant ASSERTION_ERC7540_4_WITHDRAW =
+        "!!! ERC7540-4: withdraw with more than max should revert";
+    string constant ASSERTION_ERC7540_4_REDEEM =
+        "!!! ERC7540-4: redeem with more than max should revert";
+    string constant ASSERTION_ERC7540_5 =
+        "!!! ERC7540-5: requestRedeem should revert if insufficient share balance";
+    string constant ASSERTION_ERC7540_7_WITHDRAW =
+        "!!! ERC7540-7: withdraw should not revert when amount <= max";
+    string constant ASSERTION_ERC7540_7_REDEEM =
+        "!!! ERC7540-7: redeem should not revert when amount <= max";
     string constant ASSERTION_CANARY =
         "!!! canary assertion";
     string constant INVARIANT_CANARY_GLOBAL_INVARIANT_FAILURE =
@@ -256,7 +310,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
             eq(
                 shares,
                 previewDepositShares,
-                "previewMint and previewDeposit equivalence (from shares)"
+                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES
             );
         }
     }
@@ -276,13 +330,13 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
             gte(
                 assets,
                 previewMintAssets_under,
-                "previewMint and previewDeposit equivalence under (from assets)"
+                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
             );
 
             lte(
                 assets,
                 previewMintAssets_over,
-                "previewMint and previewDeposit equivalence over (from assets)"
+                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS
             );
         }
     }
@@ -296,7 +350,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         gte(
             previewMintAssets,
             convertToAssets,
-            "previewMint is >= convertToAssets"
+            ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS
         );
     }
 
@@ -309,7 +363,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         gte(
             convertToShares,
             previewDepositShares,
-            "convertToShares is higher than or equal to previewDepositShares (equivalent without fees)"
+            ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT
         );
     }
 
@@ -682,7 +736,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_4_deposit(address(superVault), amt),
-            "ERC7540-4: deposit with more than max should revert"
+            ASSERTION_ERC7540_4_DEPOSIT
         );
     }
 
@@ -690,7 +744,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_4_mint(address(superVault), amt),
-            "ERC7540-4: mint with more than max should revert"
+            ASSERTION_ERC7540_4_MINT
         );
     }
 
@@ -698,7 +752,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_4_withdraw(address(superVault), amt),
-            "ERC7540-4: withdraw with more than max should revert"
+            ASSERTION_ERC7540_4_WITHDRAW
         );
     }
 
@@ -706,7 +760,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_4_redeem(address(superVault), amt),
-            "ERC7540-4: redeem with more than max should revert"
+            ASSERTION_ERC7540_4_REDEEM
         );
     }
 
@@ -715,7 +769,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_5(address(superVault), address(superVault), shares),
-            "ERC7540-5: requestRedeem should revert if insufficient share balance"
+            ASSERTION_ERC7540_5
         );
     }
 
@@ -752,7 +806,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         actor = _getActor();
         t(
             erc7540_7_withdraw(address(superVault), amt),
-            "ERC7540-7: withdraw should not revert when amount <= max"
+            ASSERTION_ERC7540_7_WITHDRAW
         );
     }
 
@@ -781,7 +835,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
             if (amt > 0 && assets > 0) {
                 t(
                     false,
-                    "ERC7540-7: redeem should not revert when amount <= max"
+                    ASSERTION_ERC7540_7_REDEEM
                 );
             }
         }

--- a/test/recon/targets/AdminTargets.sol
+++ b/test/recon/targets/AdminTargets.sol
@@ -388,7 +388,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         gte(
             assetBalanceAfter,
             summedExpectedAssets,
-            "strategy incurs loss on fulfillment"
+            ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT
         );
     }
 

--- a/test/recon/targets/DoomsdayTargets.sol
+++ b/test/recon/targets/DoomsdayTargets.sol
@@ -28,7 +28,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
         eq(
             previewDepositShares,
             sharesActualDeposit,
-            "previewDeposit and deposit equivalence"
+            ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE
         );
     }
 
@@ -42,7 +42,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
         eq(
             previewMintAssets,
             assetsActualMint,
-            "previewMint and mint equivalence"
+            ASSERTION_PREVIEW_MINT_EQUIVALENCE
         );
     }
 
@@ -118,7 +118,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
         gte(
             balanceAfter + TOLERANCE + feeDelta,
             balanceBefore,
-            "User loses assets in deposit/withdrawal flow"
+            ASSERTION_MINT_REDEEM_SYMMETRICAL
         );
     }
 
@@ -161,7 +161,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
         gte(
             balanceAfter + TOLERANCE,
             balanceBefore,
-            "User loses assets in deposit/withdrawal flow"
+            ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL
         );
 
         return (balanceAfter, balanceBefore);
@@ -200,7 +200,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
             eq(
                 maxRedeemAfterClaim,
                 0,
-                "maxRedeem should be reset to 0 after full redemption"
+                ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION
             );
         } catch {
             if (maxRedeemBeforeClaim > 0) {
@@ -240,7 +240,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
             eq(
                 maxWithdrawAfter,
                 0,
-                "maxWithdraw should be reset to 0 after full withdrawal"
+                ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL
             );
         } catch {
             t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
@@ -320,7 +320,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
         lte(
             totalPendingBefore - totalPendingAfter,
             totalRequestedShares,
-            "Total shares redeemed must not exceed sum of requested shares"
+            ASSERTION_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS
         );
     }
 

--- a/test/recon/targets/SuperVaultTargets.sol
+++ b/test/recon/targets/SuperVaultTargets.sol
@@ -83,17 +83,17 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         eq(
             pendingRedeemRequestsAfter,
             0,
-            "pendingRedeemRequests should be 0 after cancelling a redemption"
+            ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO
         );
         eq(
             averageRequestPPS,
             0,
-            "averageRequestPPS should be 0 after cancelling a redemption"
+            ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO
         );
         lte(
             balanceAfter - balanceBefore,
             pendingRedeemRequestsAsAssets,
-            "user shouldn't receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem"
+            ASSERTION_CANCEL_REDEEM_NO_OVERPAY
         );
     }
 
@@ -109,7 +109,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         eq(
             previewShares,
             shares,
-            "previewDeposit returns the correct amounts compared to executing a deposit"
+            ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION
         );
     }
 
@@ -125,7 +125,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         eq(
             assets,
             previewMint,
-            "previewMint returns the correct amounts compared to executing a mint"
+            ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION
         );
     }
 
@@ -192,14 +192,14 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                     stateSenderAfter.accumulatorShares,
                 stateRecipientAfter.accumulatorShares -
                     stateRecipientBefore.accumulatorShares,
-                "shares are lost on transfer"
+                ASSERTION_TRANSFER_SHARES_CONSERVED
             );
             eq(
                 stateSenderBefore.accumulatorCostBasis -
                     stateSenderAfter.accumulatorCostBasis,
                 stateRecipientAfter.accumulatorCostBasis -
                     stateRecipientBefore.accumulatorCostBasis,
-                "cost basis is lost on transfer"
+                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
             );
         } catch (bytes memory err) {
             bool expectedError;


### PR DESCRIPTION
## Summary
- centralize assertion failure reasons in `test/recon/Properties.sol` as `ASSERTION_*` constants
- ensure every assertion failure reason starts with `!!!`
- replace inline assertion reason literals in recon handlers/properties with those constants
- add missing Foundry compatibility wrappers in `test/recon/CryticToFoundry.sol` using the `invariant_assertion_failure_*` pattern (one wrapper per assertion constant)

## Files changed
- `test/recon/Properties.sol`
- `test/recon/CryticToFoundry.sol`
- `test/recon/targets/DoomsdayTargets.sol`
- `test/recon/targets/SuperVaultTargets.sol`
- `test/recon/targets/AdminTargets.sol`

## Validation
- `forge test --match-contract CryticToFoundry --list`
  - passes and lists the new `invariant_assertion_failure_*` wrappers

## References
- https://github.com/Recon-Fuzz/scfuzzbench/issues/91
- https://github.com/foundry-rs/foundry/issues/13322
