### PR TITLE
Recon onboarding compliance: assertion naming + wrapper normalization

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -112,7 +112,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         assertTrue(!assertionFailures[reason], reason);
     }
 
-    function invariant_assertion_failure_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT()
+    function invariant_assertion_failure_doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT()
         public
         view
     {
@@ -122,7 +122,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT()
+    function invariant_assertion_failure_doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT()
         public
         view
     {
@@ -134,7 +134,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_PRIMARY_MANAGER_ALWAYS_CHANGEABLE()
+    function invariant_assertion_failure_doomsday_primaryManagerAlwaysChangeable_ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE()
         public
         view
     {
@@ -144,7 +144,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED()
+    function invariant_assertion_failure_doomsday_allUsersCanWithdraw_ASSERTION_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED()
         public
         view
     {
@@ -154,7 +154,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM()
+    function invariant_assertion_failure_doomsday_redemptionsNeverReverts_ASSERTION_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM()
         public
         view
     {
@@ -166,7 +166,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_UPDATE_SHOULD_NOT_REVERT_TRANSFER()
+    function invariant_assertion_failure_superVault_transfer_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER()
         public
         view
     {
@@ -176,7 +176,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM()
+    function invariant_assertion_failure_superVault_transferFrom_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM()
         public
         view
     {
@@ -188,35 +188,35 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_PREVIEW_DEPOSIT_EQUIVALENCE()
+    function invariant_assertion_failure_doomsday_previewDepositEquivalence_ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE);
     }
 
-    function invariant_assertion_failure_PREVIEW_MINT_EQUIVALENCE()
+    function invariant_assertion_failure_doomsday_previewMintEquivalence_ASSERTION_PREVIEW_MINT_EQUIVALENCE()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_PREVIEW_MINT_EQUIVALENCE);
     }
 
-    function invariant_assertion_failure_MINT_REDEEM_SYMMETRICAL()
+    function invariant_assertion_failure_doomsday_mintRedeemSymmetrical_ASSERTION_MINT_REDEEM_SYMMETRICAL()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_MINT_REDEEM_SYMMETRICAL);
     }
 
-    function invariant_assertion_failure_DEPOSIT_WITHDRAW_SYMMETRICAL()
+    function invariant_assertion_failure_doomsday_depositWithdrawSymmetrical_ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL);
     }
 
-    function invariant_assertion_failure_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION()
+    function invariant_assertion_failure_doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION()
         public
         view
     {
@@ -225,7 +225,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL()
+    function invariant_assertion_failure_doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL()
         public
         view
     {
@@ -234,7 +234,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS()
+    function invariant_assertion_failure_doomsday_fulfillDoesntOverRedeemMultipleActors_ASSERTION_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS()
         public
         view
     {
@@ -243,70 +243,70 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
+    function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO);
     }
 
-    function invariant_assertion_failure_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
+    function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO);
     }
 
-    function invariant_assertion_failure_CANCEL_REDEEM_NO_OVERPAY()
+    function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_NO_OVERPAY);
     }
 
-    function invariant_assertion_failure_PREVIEW_DEPOSIT_MATCHES_EXECUTION()
+    function invariant_assertion_failure_superVault_deposit_ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION);
     }
 
-    function invariant_assertion_failure_PREVIEW_MINT_MATCHES_EXECUTION()
+    function invariant_assertion_failure_superVault_mint_ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION);
     }
 
-    function invariant_assertion_failure_TRANSFER_SHARES_CONSERVED()
+    function invariant_assertion_failure_superVault_transfer_ASSERTION_TRANSFER_SHARES_CONSERVED()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_TRANSFER_SHARES_CONSERVED);
     }
 
-    function invariant_assertion_failure_TRANSFER_COST_BASIS_CONSERVED()
+    function invariant_assertion_failure_superVault_transfer_ASSERTION_TRANSFER_COST_BASIS_CONSERVED()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_TRANSFER_COST_BASIS_CONSERVED);
     }
 
-    function invariant_assertion_failure_STRATEGY_NO_LOSS_ON_FULFILLMENT()
+    function invariant_assertion_failure_superVaultStrategy_fulfillRedeemRequests_ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT);
     }
 
-    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES()
+    function invariant_assertion_failure_global_previewEquivalenceFromShares_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES()
         public
         view
     {
         _assertNoAssertionFailure(ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES);
     }
 
-    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS()
+    function invariant_assertion_failure_global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS()
         public
         view
     {
@@ -315,7 +315,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS()
+    function invariant_assertion_failure_global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS()
         public
         view
     {
@@ -324,7 +324,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS()
+    function invariant_assertion_failure_global_comparePreviewMintAndConvertToAssets_ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS()
         public
         view
     {
@@ -333,7 +333,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT()
+    function invariant_assertion_failure_global_comparePreviewDepositAndConvertToShares_ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT()
         public
         view
     {
@@ -342,35 +342,35 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         );
     }
 
-    function invariant_assertion_failure_ERC7540_4_DEPOSIT() public view {
+    function invariant_assertion_failure_global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_4_DEPOSIT);
     }
 
-    function invariant_assertion_failure_ERC7540_4_MINT() public view {
+    function invariant_assertion_failure_global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_4_MINT);
     }
 
-    function invariant_assertion_failure_ERC7540_4_WITHDRAW() public view {
+    function invariant_assertion_failure_global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_4_WITHDRAW);
     }
 
-    function invariant_assertion_failure_ERC7540_4_REDEEM() public view {
+    function invariant_assertion_failure_global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_4_REDEEM);
     }
 
-    function invariant_assertion_failure_ERC7540_5() public view {
+    function invariant_assertion_failure_global_erc7540_5_ASSERTION_ERC7540_5() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_5);
     }
 
-    function invariant_assertion_failure_ERC7540_7_WITHDRAW() public view {
+    function invariant_assertion_failure_global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_7_WITHDRAW);
     }
 
-    function invariant_assertion_failure_ERC7540_7_REDEEM() public view {
+    function invariant_assertion_failure_global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM() public view {
         _assertNoAssertionFailure(ASSERTION_ERC7540_7_REDEEM);
     }
 
-    function invariant_assertion_failure_CANARY()
+    function invariant_assertion_failure_assert_canary_ASSERTION_CANARY()
         public
         view
     {

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -299,7 +299,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint and previewDeposit equivalence (from shares)
-    function global_previewEquivalenceFromShares(uint256 shares) public {
+    function global_previewEquivalenceFromShares_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES(
+        uint256 shares
+    ) public {
         uint256 previewMintAssets = superVault.previewMint(shares);
         uint256 previewDepositShares = superVault.previewDeposit(
             previewMintAssets
@@ -316,13 +318,12 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint and previewDeposit equivalence (from assets)
-    function global_previewEquivalenceFromAssets(uint256 assets) public {
+    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS(
+        uint256 assets
+    ) public {
         uint256 previewDepositShares = superVault.previewDeposit(assets);
         uint256 previewMintAssets_under = superVault.previewMint(
             previewDepositShares
-        );
-        uint256 previewMintAssets_over = superVault.previewMint(
-            previewDepositShares + 1
         );
         uint256 price = superVaultStrategy.getStoredPPS();
 
@@ -332,7 +333,20 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
                 previewMintAssets_under,
                 ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
             );
+        }
+    }
 
+    /// @dev Property: previewMint and previewDeposit equivalence (from assets)
+    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS(
+        uint256 assets
+    ) public {
+        uint256 previewDepositShares = superVault.previewDeposit(assets);
+        uint256 previewMintAssets_over = superVault.previewMint(
+            previewDepositShares + 1
+        );
+        uint256 price = superVaultStrategy.getStoredPPS();
+
+        if (price > 0) {
             lte(
                 assets,
                 previewMintAssets_over,
@@ -342,7 +356,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint is >= convertToAssets
-    function global_comparePreviewMintAndConvertToAssets(
+    function global_comparePreviewMintAndConvertToAssets_ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS(
         uint256 shares
     ) public {
         uint256 previewMintAssets = superVault.previewMint(shares);
@@ -355,7 +369,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: convertToShares is >= previewDepositShares (equivalent without fees)
-    function global_comparePreviewDepositAndConvertToShares(
+    function global_comparePreviewDepositAndConvertToShares_ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT(
         uint256 assets
     ) public {
         uint256 previewDepositShares = superVault.previewDeposit(assets);
@@ -692,7 +706,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     // Canaries
 
     /// @dev Canary assertion helper. A failing input is expected to be discovered during fuzzing.
-    function assert_canary(uint256 entropy) public {
+    function assert_canary_ASSERTION_CANARY(uint256 entropy) public {
         t(entropy > 0, ASSERTION_CANARY);
     }
 
@@ -732,7 +746,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-4: claiming more than max always reverts
-    function global_erc7540_4_deposit(uint256 amt) public stateless {
+    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_4_deposit(address(superVault), amt),
@@ -740,7 +756,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_mint(uint256 amt) public stateless {
+    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_4_mint(address(superVault), amt),
@@ -748,7 +766,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_withdraw(uint256 amt) public stateless {
+    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_4_withdraw(address(superVault), amt),
@@ -756,7 +776,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_redeem(uint256 amt) public stateless {
+    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_4_redeem(address(superVault), amt),
@@ -765,7 +787,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-5: requestRedeem reverts if the share balance is less than amount
-    function global_erc7540_5(uint256 shares) public stateless {
+    function global_erc7540_5_ASSERTION_ERC7540_5(
+        uint256 shares
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_5(address(superVault), address(superVault), shares),
@@ -802,7 +826,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     //     );
     // }
 
-    function global_erc7540_7_withdraw(uint256 amt) public stateless {
+    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
         t(
             erc7540_7_withdraw(address(superVault), amt),
@@ -811,7 +837,9 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     // NOTE: this implements the check from ERC7540Properties directly because SuperVault logic implementation allows amt to be nonzero but round down to 0 when assets passed into redeem are calculated
-    function global_erc7540_7_redeem(uint256 amt) public stateless {
+    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(
+        uint256 amt
+    ) public stateless {
         actor = _getActor();
 
         uint256 maxRedeem = superVault.maxRedeem(actor);

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -299,9 +299,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint and previewDeposit equivalence (from shares)
-    function global_previewEquivalenceFromShares_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES(
-        uint256 shares
-    ) public {
+    function global_previewEquivalenceFromShares_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES(uint256 shares) public {
         uint256 previewMintAssets = superVault.previewMint(shares);
         uint256 previewDepositShares = superVault.previewDeposit(
             previewMintAssets
@@ -318,12 +316,13 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint and previewDeposit equivalence (from assets)
-    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS(
-        uint256 assets
-    ) public {
+    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS(uint256 assets) public {
         uint256 previewDepositShares = superVault.previewDeposit(assets);
         uint256 previewMintAssets_under = superVault.previewMint(
             previewDepositShares
+        );
+        uint256 previewMintAssets_over = superVault.previewMint(
+            previewDepositShares + 1
         );
         uint256 price = superVaultStrategy.getStoredPPS();
 
@@ -333,20 +332,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
                 previewMintAssets_under,
                 ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
             );
-        }
-    }
 
-    /// @dev Property: previewMint and previewDeposit equivalence (from assets)
-    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS(
-        uint256 assets
-    ) public {
-        uint256 previewDepositShares = superVault.previewDeposit(assets);
-        uint256 previewMintAssets_over = superVault.previewMint(
-            previewDepositShares + 1
-        );
-        uint256 price = superVaultStrategy.getStoredPPS();
-
-        if (price > 0) {
             lte(
                 assets,
                 previewMintAssets_over,
@@ -746,9 +732,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-4: claiming more than max always reverts
-    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_deposit(address(superVault), amt),
@@ -756,9 +740,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_mint(address(superVault), amt),
@@ -766,9 +748,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_withdraw(address(superVault), amt),
@@ -776,9 +756,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_redeem(address(superVault), amt),
@@ -787,9 +765,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-5: requestRedeem reverts if the share balance is less than amount
-    function global_erc7540_5_ASSERTION_ERC7540_5(
-        uint256 shares
-    ) public stateless {
+    function global_erc7540_5_ASSERTION_ERC7540_5(uint256 shares) public stateless {
         actor = _getActor();
         t(
             erc7540_5(address(superVault), address(superVault), shares),
@@ -826,9 +802,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     //     );
     // }
 
-    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_7_withdraw(address(superVault), amt),
@@ -837,9 +811,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     // NOTE: this implements the check from ERC7540Properties directly because SuperVault logic implementation allows amt to be nonzero but round down to 0 when assets passed into redeem are calculated
-    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(
-        uint256 amt
-    ) public stateless {
+    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(uint256 amt) public stateless {
         actor = _getActor();
 
         uint256 maxRedeem = superVault.maxRedeem(actor);

--- a/test/recon/targets/AdminTargets.sol
+++ b/test/recon/targets/AdminTargets.sol
@@ -369,8 +369,16 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         executeHooksSuccess = true;
     }
 
-    /// @dev Property: superVaultStrategy does not incur loss on fulfillment
+    /// @dev Action: fulfill pending redeem requests.
     function superVaultStrategy_fulfillRedeemRequests(
+        ISuperVaultStrategy.FulfillArgs memory args
+    ) public updateGhostsWithOpType(OpType.FULFILL) {
+        // no need to prank because called as admin address(this)
+        superVaultStrategy.fulfillRedeemRequests(args);
+    }
+
+    /// @dev Property: superVaultStrategy does not incur loss on fulfillment.
+    function superVaultStrategy_fulfillRedeemRequests_ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT(
         ISuperVaultStrategy.FulfillArgs memory args
     ) public updateGhostsWithOpType(OpType.FULFILL) {
         uint256 summedExpectedAssets;

--- a/test/recon/targets/AdminTargets.sol
+++ b/test/recon/targets/AdminTargets.sol
@@ -356,7 +356,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
             });
 
         // Execute the function
-        superVaultStrategy_fulfillRedeemRequests(fulfillArgs);
+        superVaultStrategy_fulfillRedeemRequests_ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT(fulfillArgs);
     }
 
     /// AUTO GENERATED TARGET FUNCTIONS - WARNING: DO NOT DELETE OR MODIFY THIS LINE ///
@@ -369,15 +369,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         executeHooksSuccess = true;
     }
 
-    /// @dev Action: fulfill pending redeem requests.
-    function superVaultStrategy_fulfillRedeemRequests(
-        ISuperVaultStrategy.FulfillArgs memory args
-    ) public updateGhostsWithOpType(OpType.FULFILL) {
-        // no need to prank because called as admin address(this)
-        superVaultStrategy.fulfillRedeemRequests(args);
-    }
-
-    /// @dev Property: superVaultStrategy does not incur loss on fulfillment.
+    /// @dev Property: superVaultStrategy does not incur loss on fulfillment
     function superVaultStrategy_fulfillRedeemRequests_ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT(
         ISuperVaultStrategy.FulfillArgs memory args
     ) public updateGhostsWithOpType(OpType.FULFILL) {

--- a/test/recon/targets/DoomsdayTargets.sol
+++ b/test/recon/targets/DoomsdayTargets.sol
@@ -17,7 +17,7 @@ import {MockERC7540Tester} from "test/recon/mocks/MockERC7540Tester.sol";
 
 abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     /// @dev Property: previewDeposit and deposit equivalence
-    function doomsday_previewDepositEquivalence(
+    function doomsday_previewDepositEquivalence_ASSERTION_PREVIEW_DEPOSIT_EQUIVALENCE(
         uint256 assets
     ) public stateless {
         uint256 previewDepositShares = superVault.previewDeposit(assets);
@@ -33,7 +33,9 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: previewMint and mint equivalence
-    function doomsday_previewMintEquivalence(uint256 shares) public stateless {
+    function doomsday_previewMintEquivalence_ASSERTION_PREVIEW_MINT_EQUIVALENCE(
+        uint256 shares
+    ) public stateless {
         uint256 previewMintAssets = superVault.previewMint(shares);
 
         vm.prank(_getActor());
@@ -47,7 +49,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: mint/redeem doesn't cause loss to user
-    function doomsday_mintRedeemSymmetrical(
+    function doomsday_mintRedeemSymmetrical_ASSERTION_MINT_REDEEM_SYMMETRICAL(
         uint256 sharesToMint
     ) public stateless {
         // skip if there's been any gain because it complicates the assertion checking
@@ -123,7 +125,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: deposit/withdraw doesn't cause loss to user
-    function doomsday_depositWithdrawSymmetrical(
+    function doomsday_depositWithdrawSymmetrical_ASSERTION_DEPOSIT_WITHDRAW_SYMMETRICAL(
         uint256 assetsToDeposit
     ) public stateless returns (uint256, uint256) {
         // skip if there's been any gain because it complicates the assertion checking
@@ -169,7 +171,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
 
     /// @dev Property: maxRedeem is reset to 0 after full redemption
     /// @dev Property: redeeming maxRedeem shouldn't revert
-    function doomsday_maxRedeemResetsAfterFullRedemption(
+    function doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION(
         uint256 sharesToMint
     ) public stateless {
         // 1. Deposit to get shares
@@ -202,7 +204,29 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
                 0,
                 ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION
             );
-        } catch {
+        } catch {}
+    }
+
+    /// @dev Property: redeeming maxRedeem shouldn't revert
+    function doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT(
+        uint256 sharesToMint
+    ) public stateless {
+        vm.prank(_getActor());
+        superVault.mint(sharesToMint, _getActor());
+
+        uint256 shares = superVault.balanceOf(_getActor());
+
+        vm.prank(_getActor());
+        superVault.requestRedeem(shares, _getActor(), _getActor());
+
+        ISuperVaultStrategy.FulfillArgs
+            memory fulfillArgs = _createFulfillRedeemArgs(shares);
+        superVaultStrategy.fulfillRedeemRequests(fulfillArgs);
+
+        uint256 maxRedeemBeforeClaim = superVault.maxRedeem(_getActor());
+
+        vm.prank(_getActor());
+        try superVault.redeem(maxRedeemBeforeClaim, _getActor(), _getActor()) {} catch {
             if (maxRedeemBeforeClaim > 0) {
                 t(false, ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT);
             }
@@ -210,7 +234,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: maxWithdraw is reset to 0 after full withdrawal
-    function doomsday_maxWithdrawResetsAfterFullWithdrawal(
+    function doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL(
         uint256 assetsToDeposit
     ) public stateless {
         // 1. Deposit to get shares
@@ -242,13 +266,37 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
                 0,
                 ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL
             );
-        } catch {
-            t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
+        } catch {}
+    }
+
+    /// @dev Property: withdrawing maxWithdraw shouldn't revert
+    function doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT(
+        uint256 assetsToDeposit
+    ) public stateless {
+        vm.prank(_getActor());
+        superVault.deposit(assetsToDeposit, _getActor());
+
+        uint256 shares = superVault.balanceOf(_getActor());
+
+        vm.prank(_getActor());
+        superVault.requestRedeem(shares, _getActor(), _getActor());
+
+        ISuperVaultStrategy.FulfillArgs
+            memory fulfillArgs = _createFulfillRedeemArgs(shares);
+        superVaultStrategy.fulfillRedeemRequests(fulfillArgs);
+
+        uint256 maxWithdrawBefore = superVault.maxWithdraw(_getActor());
+
+        vm.prank(_getActor());
+        try superVault.withdraw(maxWithdrawBefore, _getActor(), _getActor()) {} catch {
+            if (maxWithdrawBefore > 0) {
+                t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
+            }
         }
     }
 
     /// @dev Property: fulfillRedeemRequests doesn't redeem more than requested for multiple actors
-    function doomsday_fulfillDoesntOverRedeemMultipleActors(
+    function doomsday_fulfillDoesntOverRedeemMultipleActors_ASSERTION_FULFILL_DOESNT_OVER_REDEEM_MULTIPLE_ACTORS(
         uint256[3] memory sharesToMint,
         uint256[3] memory actorIndexes
     ) public stateless {
@@ -325,7 +373,10 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: primary manager can always be replaced by governance via `changePrimaryManager`
-    function doomsday_primaryManagerAlwaysChangeable() public stateless {
+    function doomsday_primaryManagerAlwaysChangeable_ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE()
+        public
+        stateless
+    {
         address strategy = address(superVaultStrategy);
         address newManager = _getActor();
 
@@ -346,7 +397,10 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     /// @dev Property: all users can withdraw (solvency)
     // NOTE: if withdrawing from a given strategy via fulfillRedeemRequests fails, it can be expected that one of the YieldSourceTargets would be called to switch the yield source
     // this should allow fulfillments to eventually succeed so we don't need to sort through all yield sources that have currently been deposited into before fulfilling
-    function doomsday_allUsersCanWithdraw() public stateless {
+    function doomsday_allUsersCanWithdraw_ASSERTION_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED()
+        public
+        stateless
+    {
         address[] memory actors = _getActors();
         bool paused = superVaultAggregator.isStrategyPaused(
             address(superVaultStrategy)
@@ -397,7 +451,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: Claiming redemptions should never revert with INVALID_REDEEM_CLAIM
-    function doomsday_redemptionsNeverReverts(
+    function doomsday_redemptionsNeverReverts_ASSERTION_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM(
         uint256 shares
     ) public asActor stateless {
         try superVault.redeem(shares, _getActor(), _getActor()) {} catch (

--- a/test/recon/targets/DoomsdayTargets.sol
+++ b/test/recon/targets/DoomsdayTargets.sol
@@ -33,9 +33,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: previewMint and mint equivalence
-    function doomsday_previewMintEquivalence_ASSERTION_PREVIEW_MINT_EQUIVALENCE(
-        uint256 shares
-    ) public stateless {
+    function doomsday_previewMintEquivalence_ASSERTION_PREVIEW_MINT_EQUIVALENCE(uint256 shares) public stateless {
         uint256 previewMintAssets = superVault.previewMint(shares);
 
         vm.prank(_getActor());
@@ -204,29 +202,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
                 0,
                 ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION
             );
-        } catch {}
-    }
-
-    /// @dev Property: redeeming maxRedeem shouldn't revert
-    function doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT(
-        uint256 sharesToMint
-    ) public stateless {
-        vm.prank(_getActor());
-        superVault.mint(sharesToMint, _getActor());
-
-        uint256 shares = superVault.balanceOf(_getActor());
-
-        vm.prank(_getActor());
-        superVault.requestRedeem(shares, _getActor(), _getActor());
-
-        ISuperVaultStrategy.FulfillArgs
-            memory fulfillArgs = _createFulfillRedeemArgs(shares);
-        superVaultStrategy.fulfillRedeemRequests(fulfillArgs);
-
-        uint256 maxRedeemBeforeClaim = superVault.maxRedeem(_getActor());
-
-        vm.prank(_getActor());
-        try superVault.redeem(maxRedeemBeforeClaim, _getActor(), _getActor()) {} catch {
+        } catch {
             if (maxRedeemBeforeClaim > 0) {
                 t(false, ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT);
             }
@@ -266,32 +242,8 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
                 0,
                 ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL
             );
-        } catch {}
-    }
-
-    /// @dev Property: withdrawing maxWithdraw shouldn't revert
-    function doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT(
-        uint256 assetsToDeposit
-    ) public stateless {
-        vm.prank(_getActor());
-        superVault.deposit(assetsToDeposit, _getActor());
-
-        uint256 shares = superVault.balanceOf(_getActor());
-
-        vm.prank(_getActor());
-        superVault.requestRedeem(shares, _getActor(), _getActor());
-
-        ISuperVaultStrategy.FulfillArgs
-            memory fulfillArgs = _createFulfillRedeemArgs(shares);
-        superVaultStrategy.fulfillRedeemRequests(fulfillArgs);
-
-        uint256 maxWithdrawBefore = superVault.maxWithdraw(_getActor());
-
-        vm.prank(_getActor());
-        try superVault.withdraw(maxWithdrawBefore, _getActor(), _getActor()) {} catch {
-            if (maxWithdrawBefore > 0) {
-                t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
-            }
+        } catch {
+            t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
         }
     }
 
@@ -373,10 +325,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     }
 
     /// @dev Property: primary manager can always be replaced by governance via `changePrimaryManager`
-    function doomsday_primaryManagerAlwaysChangeable_ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE()
-        public
-        stateless
-    {
+    function doomsday_primaryManagerAlwaysChangeable_ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE() public stateless {
         address strategy = address(superVaultStrategy);
         address newManager = _getActor();
 
@@ -397,10 +346,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
     /// @dev Property: all users can withdraw (solvency)
     // NOTE: if withdrawing from a given strategy via fulfillRedeemRequests fails, it can be expected that one of the YieldSourceTargets would be called to switch the yield source
     // this should allow fulfillments to eventually succeed so we don't need to sort through all yield sources that have currently been deposited into before fulfilling
-    function doomsday_allUsersCanWithdraw_ASSERTION_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED()
-        public
-        stateless
-    {
+    function doomsday_allUsersCanWithdraw_ASSERTION_ALL_USERS_CAN_WITHDRAW_WHEN_UNPAUSED() public stateless {
         address[] memory actors = _getActors();
         bool paused = superVaultAggregator.isStrategyPaused(
             address(superVaultStrategy)

--- a/test/recon/targets/SuperVaultTargets.sol
+++ b/test/recon/targets/SuperVaultTargets.sol
@@ -47,58 +47,116 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         superVault.burnShares(amount);
     }
 
-    /// @dev Property: pendingRedeemRequest should be 0 after a user calls cancelRedeem
-    /// @dev Property: averageRequestPPS should be 0 after a user calls cancelRedeem
-    /// @dev Property: user shouldn't receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem
-    function superVault_cancelRedeem()
-        public
-        updateGhostsWithOpType(OpType.CANCEL)
+    struct CancelRedeemContext {
+        uint256 pendingRedeemRequestsAsAssets;
+        uint256 pendingRedeemRequestsAfter;
+        uint256 averageRequestPPS;
+        uint256 balanceBefore;
+        uint256 balanceAfter;
+    }
+
+    struct TransferContext {
+        bool success;
+        bool expectedError;
+        uint256 senderAccumulatorSharesDelta;
+        uint256 recipientAccumulatorSharesDelta;
+        uint256 senderAccumulatorCostBasisDelta;
+        uint256 recipientAccumulatorCostBasisDelta;
+    }
+
+    function _executeCancelRedeem()
+        internal
+        returns (CancelRedeemContext memory context)
     {
         uint256 pendingRedeemRequestsBefore = superVault.pendingRedeemRequest(
             0,
             _getActor()
         );
-        uint256 pendingRedeemRequestsAsAssets = superVault.convertToAssets(
+        context.pendingRedeemRequestsAsAssets = superVault.convertToAssets(
             pendingRedeemRequestsBefore
         );
-        uint256 balanceBefore = MockERC20(superVault.asset()).balanceOf(
+        context.balanceBefore = MockERC20(superVault.asset()).balanceOf(
             _getActor()
         );
 
         vm.prank(_getActor());
         superVault.cancelRedeem(_getActor());
 
-        uint256 pendingRedeemRequestsAfter = superVault.pendingRedeemRequest(
+        context.pendingRedeemRequestsAfter = superVault.pendingRedeemRequest(
             0,
             _getActor()
         );
-        uint256 averageRequestPPS = superVaultStrategy
+        context.averageRequestPPS = superVaultStrategy
             .getSuperVaultState(_getActor())
             .averageRequestPPS;
-        uint256 balanceAfter = MockERC20(superVault.asset()).balanceOf(
+        context.balanceAfter = MockERC20(superVault.asset()).balanceOf(
             _getActor()
         );
+    }
 
-        // Checks
+    /// @dev Action: cancel a pending redemption request for the current actor.
+    function superVault_cancelRedeem()
+        public
+        updateGhostsWithOpType(OpType.CANCEL)
+    {
+        _executeCancelRedeem();
+    }
+
+    /// @dev Property: pendingRedeemRequest should be 0 after a user calls cancelRedeem
+    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
+        public
+        updateGhostsWithOpType(OpType.CANCEL)
+    {
+        CancelRedeemContext memory context = _executeCancelRedeem();
+
         eq(
-            pendingRedeemRequestsAfter,
+            context.pendingRedeemRequestsAfter,
             0,
             ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO
         );
+    }
+
+    /// @dev Property: averageRequestPPS should be 0 after a user calls cancelRedeem
+    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
+        public
+        updateGhostsWithOpType(OpType.CANCEL)
+    {
+        CancelRedeemContext memory context = _executeCancelRedeem();
+
         eq(
-            averageRequestPPS,
+            context.averageRequestPPS,
             0,
             ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO
         );
+    }
+
+    /// @dev Property: user should not receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem
+    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY()
+        public
+        updateGhostsWithOpType(OpType.CANCEL)
+    {
+        CancelRedeemContext memory context = _executeCancelRedeem();
+        uint256 refundedAssets = context.balanceAfter > context.balanceBefore
+            ? context.balanceAfter - context.balanceBefore
+            : 0;
+
         lte(
-            balanceAfter - balanceBefore,
-            pendingRedeemRequestsAsAssets,
+            refundedAssets,
+            context.pendingRedeemRequestsAsAssets,
             ASSERTION_CANCEL_REDEEM_NO_OVERPAY
         );
     }
 
-    /// @dev Property: previewDeposit returns the correct amounts compared to executing a deposit
+    /// @dev Action: deposit assets for the current actor.
     function superVault_deposit(
+        uint256 assets
+    ) public updateGhostsWithOpType(OpType.ADD) {
+        vm.prank(_getActor());
+        superVault.deposit(assets, _getActor());
+    }
+
+    /// @dev Property: previewDeposit returns the correct amounts compared to executing a deposit
+    function superVault_deposit_ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION(
         uint256 assets
     ) public updateGhostsWithOpType(OpType.ADD) {
         uint256 previewShares = superVault.previewDeposit(assets);
@@ -113,8 +171,16 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         );
     }
 
-    /// @dev Property: previewMint returns the correct amounts compared to executing a mint
+    /// @dev Action: mint shares for the current actor.
     function superVault_mint(
+        uint256 shares
+    ) public updateGhostsWithOpType(OpType.ADD) {
+        vm.prank(_getActor());
+        superVault.mint(shares, _getActor());
+    }
+
+    /// @dev Property: previewMint returns the correct amounts compared to executing a mint
+    function superVault_mint_ASSERTION_PREVIEW_MINT_MATCHES_EXECUTION(
         uint256 shares
     ) public updateGhostsWithOpType(OpType.ADD) {
         uint256 previewMint = superVault.previewMint(shares);
@@ -159,14 +225,10 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         superVault.setOperator(operator, approved);
     }
 
-    /// @dev Propery: _update should never revert
-    /// @dev Property: Transfers of shares should transfer the exact amount of accumulatorShares to the recipient
-    /// @dev Property: Transfers of shares should transfer the exact amount of accumulatorCostBasis to the recipient
-    // NOTE: _update only gets called on transfer of Vault shares
-    function superVault_transfer(
+    function _executeTransfer(
         uint256 entropy,
         uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+    ) internal returns (TransferContext memory context) {
         address to = _getRandomActor(entropy);
         ISuperVaultStrategy.SuperVaultState
             memory stateSenderBefore = superVaultStrategy.getSuperVaultState(
@@ -179,6 +241,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
 
         vm.prank(_getActor());
         try superVault.transfer(to, value) {
+            context.success = true;
             ISuperVaultStrategy.SuperVaultState
                 memory stateSenderAfter = superVaultStrategy.getSuperVaultState(
                     _getActor()
@@ -187,45 +250,89 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                 memory stateRecipientAfter = superVaultStrategy
                     .getSuperVaultState(to);
 
-            eq(
+            context.senderAccumulatorSharesDelta =
                 stateSenderBefore.accumulatorShares -
-                    stateSenderAfter.accumulatorShares,
+                stateSenderAfter.accumulatorShares;
+            context.recipientAccumulatorSharesDelta =
                 stateRecipientAfter.accumulatorShares -
-                    stateRecipientBefore.accumulatorShares,
-                ASSERTION_TRANSFER_SHARES_CONSERVED
-            );
-            eq(
+                stateRecipientBefore.accumulatorShares;
+            context.senderAccumulatorCostBasisDelta =
                 stateSenderBefore.accumulatorCostBasis -
-                    stateSenderAfter.accumulatorCostBasis,
+                stateSenderAfter.accumulatorCostBasis;
+            context.recipientAccumulatorCostBasisDelta =
                 stateRecipientAfter.accumulatorCostBasis -
-                    stateRecipientBefore.accumulatorCostBasis,
-                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
-            );
+                stateRecipientBefore.accumulatorCostBasis;
         } catch (bytes memory err) {
-            bool expectedError;
-            expectedError = checkError(
+            context.expectedError = checkError(
                 err,
                 "ERC20InsufficientBalance(address,uint256,uint256)"
             );
-            t(expectedError, ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER);
         }
     }
 
-    /// @dev Propery: _update should never revert
-    // NOTE: _update only gets called on transfer of Vault shares
-    function superVault_transferFrom(
+    /// @dev Action: transfer shares from the current actor to a random actor.
+    function superVault_transfer(
+        uint256 entropy,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        _executeTransfer(entropy, value);
+    }
+
+    /// @dev Property: transfers of shares should transfer the exact amount of accumulatorShares to the recipient.
+    function superVault_transfer_ASSERTION_TRANSFER_SHARES_CONSERVED(
+        uint256 entropy,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        TransferContext memory context = _executeTransfer(entropy, value);
+        if (context.success) {
+            eq(
+                context.senderAccumulatorSharesDelta,
+                context.recipientAccumulatorSharesDelta,
+                ASSERTION_TRANSFER_SHARES_CONSERVED
+            );
+        }
+    }
+
+    /// @dev Property: transfers of shares should transfer the exact amount of accumulatorCostBasis to the recipient.
+    function superVault_transfer_ASSERTION_TRANSFER_COST_BASIS_CONSERVED(
+        uint256 entropy,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        TransferContext memory context = _executeTransfer(entropy, value);
+        if (context.success) {
+            eq(
+                context.senderAccumulatorCostBasisDelta,
+                context.recipientAccumulatorCostBasisDelta,
+                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
+            );
+        }
+    }
+
+    /// @dev Property: _update should never revert in transfer unless balance is insufficient.
+    function superVault_transfer_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER(
+        uint256 entropy,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        TransferContext memory context = _executeTransfer(entropy, value);
+        if (!context.success) {
+            t(context.expectedError, ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER);
+        }
+    }
+
+    function _executeTransferFrom(
         uint256 entropyFrom,
         uint256 entropyTo,
         uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+    ) internal returns (bool success, bool expectedError) {
         address from = _getRandomActor(entropyFrom);
         address to = _getRandomActor(entropyTo);
 
         vm.prank(_getActor());
-        try superVault.transferFrom(from, to, value) {} catch (
+        try superVault.transferFrom(from, to, value) {
+            success = true;
+        } catch (
             bytes memory err
         ) {
-            bool expectedError;
             expectedError =
                 checkError(
                     err,
@@ -235,6 +342,30 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                     err,
                     "ERC20InsufficientAllowance(address,uint256,uint256)"
                 );
+        }
+    }
+
+    /// @dev Action: transfer shares on behalf of another actor.
+    function superVault_transferFrom(
+        uint256 entropyFrom,
+        uint256 entropyTo,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        _executeTransferFrom(entropyFrom, entropyTo, value);
+    }
+
+    /// @dev Property: _update should never revert in transferFrom unless balance/allowance is insufficient.
+    function superVault_transferFrom_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM(
+        uint256 entropyFrom,
+        uint256 entropyTo,
+        uint256 value
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
+        (bool success, bool expectedError) = _executeTransferFrom(
+            entropyFrom,
+            entropyTo,
+            value
+        );
+        if (!success) {
             t(
                 expectedError,
                 ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM

--- a/test/recon/targets/SuperVaultTargets.sol
+++ b/test/recon/targets/SuperVaultTargets.sol
@@ -47,112 +47,54 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         superVault.burnShares(amount);
     }
 
-    struct CancelRedeemContext {
-        uint256 pendingRedeemRequestsAsAssets;
-        uint256 pendingRedeemRequestsAfter;
-        uint256 averageRequestPPS;
-        uint256 balanceBefore;
-        uint256 balanceAfter;
-    }
-
-    struct TransferContext {
-        bool success;
-        bool expectedError;
-        uint256 senderAccumulatorSharesDelta;
-        uint256 recipientAccumulatorSharesDelta;
-        uint256 senderAccumulatorCostBasisDelta;
-        uint256 recipientAccumulatorCostBasisDelta;
-    }
-
-    function _executeCancelRedeem()
-        internal
-        returns (CancelRedeemContext memory context)
+    /// @dev Property: pendingRedeemRequest should be 0 after a user calls cancelRedeem
+    /// @dev Property: averageRequestPPS should be 0 after a user calls cancelRedeem
+    /// @dev Property: user shouldn't receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem
+    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
+        public
+        updateGhostsWithOpType(OpType.CANCEL)
     {
         uint256 pendingRedeemRequestsBefore = superVault.pendingRedeemRequest(
             0,
             _getActor()
         );
-        context.pendingRedeemRequestsAsAssets = superVault.convertToAssets(
+        uint256 pendingRedeemRequestsAsAssets = superVault.convertToAssets(
             pendingRedeemRequestsBefore
         );
-        context.balanceBefore = MockERC20(superVault.asset()).balanceOf(
+        uint256 balanceBefore = MockERC20(superVault.asset()).balanceOf(
             _getActor()
         );
 
         vm.prank(_getActor());
         superVault.cancelRedeem(_getActor());
 
-        context.pendingRedeemRequestsAfter = superVault.pendingRedeemRequest(
+        uint256 pendingRedeemRequestsAfter = superVault.pendingRedeemRequest(
             0,
             _getActor()
         );
-        context.averageRequestPPS = superVaultStrategy
+        uint256 averageRequestPPS = superVaultStrategy
             .getSuperVaultState(_getActor())
             .averageRequestPPS;
-        context.balanceAfter = MockERC20(superVault.asset()).balanceOf(
+        uint256 balanceAfter = MockERC20(superVault.asset()).balanceOf(
             _getActor()
         );
-    }
 
-    /// @dev Action: cancel a pending redemption request for the current actor.
-    function superVault_cancelRedeem()
-        public
-        updateGhostsWithOpType(OpType.CANCEL)
-    {
-        _executeCancelRedeem();
-    }
-
-    /// @dev Property: pendingRedeemRequest should be 0 after a user calls cancelRedeem
-    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
-        public
-        updateGhostsWithOpType(OpType.CANCEL)
-    {
-        CancelRedeemContext memory context = _executeCancelRedeem();
-
+        // Checks
         eq(
-            context.pendingRedeemRequestsAfter,
+            pendingRedeemRequestsAfter,
             0,
             ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO
         );
-    }
-
-    /// @dev Property: averageRequestPPS should be 0 after a user calls cancelRedeem
-    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
-        public
-        updateGhostsWithOpType(OpType.CANCEL)
-    {
-        CancelRedeemContext memory context = _executeCancelRedeem();
-
         eq(
-            context.averageRequestPPS,
+            averageRequestPPS,
             0,
             ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO
         );
-    }
-
-    /// @dev Property: user should not receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem
-    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY()
-        public
-        updateGhostsWithOpType(OpType.CANCEL)
-    {
-        CancelRedeemContext memory context = _executeCancelRedeem();
-        uint256 refundedAssets = context.balanceAfter > context.balanceBefore
-            ? context.balanceAfter - context.balanceBefore
-            : 0;
-
         lte(
-            refundedAssets,
-            context.pendingRedeemRequestsAsAssets,
+            balanceAfter - balanceBefore,
+            pendingRedeemRequestsAsAssets,
             ASSERTION_CANCEL_REDEEM_NO_OVERPAY
         );
-    }
-
-    /// @dev Action: deposit assets for the current actor.
-    function superVault_deposit(
-        uint256 assets
-    ) public updateGhostsWithOpType(OpType.ADD) {
-        vm.prank(_getActor());
-        superVault.deposit(assets, _getActor());
     }
 
     /// @dev Property: previewDeposit returns the correct amounts compared to executing a deposit
@@ -169,14 +111,6 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
             shares,
             ASSERTION_PREVIEW_DEPOSIT_MATCHES_EXECUTION
         );
-    }
-
-    /// @dev Action: mint shares for the current actor.
-    function superVault_mint(
-        uint256 shares
-    ) public updateGhostsWithOpType(OpType.ADD) {
-        vm.prank(_getActor());
-        superVault.mint(shares, _getActor());
     }
 
     /// @dev Property: previewMint returns the correct amounts compared to executing a mint
@@ -225,10 +159,14 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         superVault.setOperator(operator, approved);
     }
 
-    function _executeTransfer(
+    /// @dev Propery: _update should never revert
+    /// @dev Property: Transfers of shares should transfer the exact amount of accumulatorShares to the recipient
+    /// @dev Property: Transfers of shares should transfer the exact amount of accumulatorCostBasis to the recipient
+    // NOTE: _update only gets called on transfer of Vault shares
+    function superVault_transfer_ASSERTION_TRANSFER_SHARES_CONSERVED(
         uint256 entropy,
         uint256 value
-    ) internal returns (TransferContext memory context) {
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
         address to = _getRandomActor(entropy);
         ISuperVaultStrategy.SuperVaultState
             memory stateSenderBefore = superVaultStrategy.getSuperVaultState(
@@ -241,7 +179,6 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
 
         vm.prank(_getActor());
         try superVault.transfer(to, value) {
-            context.success = true;
             ISuperVaultStrategy.SuperVaultState
                 memory stateSenderAfter = superVaultStrategy.getSuperVaultState(
                     _getActor()
@@ -250,89 +187,45 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                 memory stateRecipientAfter = superVaultStrategy
                     .getSuperVaultState(to);
 
-            context.senderAccumulatorSharesDelta =
+            eq(
                 stateSenderBefore.accumulatorShares -
-                stateSenderAfter.accumulatorShares;
-            context.recipientAccumulatorSharesDelta =
+                    stateSenderAfter.accumulatorShares,
                 stateRecipientAfter.accumulatorShares -
-                stateRecipientBefore.accumulatorShares;
-            context.senderAccumulatorCostBasisDelta =
+                    stateRecipientBefore.accumulatorShares,
+                ASSERTION_TRANSFER_SHARES_CONSERVED
+            );
+            eq(
                 stateSenderBefore.accumulatorCostBasis -
-                stateSenderAfter.accumulatorCostBasis;
-            context.recipientAccumulatorCostBasisDelta =
+                    stateSenderAfter.accumulatorCostBasis,
                 stateRecipientAfter.accumulatorCostBasis -
-                stateRecipientBefore.accumulatorCostBasis;
+                    stateRecipientBefore.accumulatorCostBasis,
+                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
+            );
         } catch (bytes memory err) {
-            context.expectedError = checkError(
+            bool expectedError;
+            expectedError = checkError(
                 err,
                 "ERC20InsufficientBalance(address,uint256,uint256)"
             );
+            t(expectedError, ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER);
         }
     }
 
-    /// @dev Action: transfer shares from the current actor to a random actor.
-    function superVault_transfer(
-        uint256 entropy,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        _executeTransfer(entropy, value);
-    }
-
-    /// @dev Property: transfers of shares should transfer the exact amount of accumulatorShares to the recipient.
-    function superVault_transfer_ASSERTION_TRANSFER_SHARES_CONSERVED(
-        uint256 entropy,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        TransferContext memory context = _executeTransfer(entropy, value);
-        if (context.success) {
-            eq(
-                context.senderAccumulatorSharesDelta,
-                context.recipientAccumulatorSharesDelta,
-                ASSERTION_TRANSFER_SHARES_CONSERVED
-            );
-        }
-    }
-
-    /// @dev Property: transfers of shares should transfer the exact amount of accumulatorCostBasis to the recipient.
-    function superVault_transfer_ASSERTION_TRANSFER_COST_BASIS_CONSERVED(
-        uint256 entropy,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        TransferContext memory context = _executeTransfer(entropy, value);
-        if (context.success) {
-            eq(
-                context.senderAccumulatorCostBasisDelta,
-                context.recipientAccumulatorCostBasisDelta,
-                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
-            );
-        }
-    }
-
-    /// @dev Property: _update should never revert in transfer unless balance is insufficient.
-    function superVault_transfer_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER(
-        uint256 entropy,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        TransferContext memory context = _executeTransfer(entropy, value);
-        if (!context.success) {
-            t(context.expectedError, ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER);
-        }
-    }
-
-    function _executeTransferFrom(
+    /// @dev Propery: _update should never revert
+    // NOTE: _update only gets called on transfer of Vault shares
+    function superVault_transferFrom_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM(
         uint256 entropyFrom,
         uint256 entropyTo,
         uint256 value
-    ) internal returns (bool success, bool expectedError) {
+    ) public updateGhostsWithOpType(OpType.TRANSFER) {
         address from = _getRandomActor(entropyFrom);
         address to = _getRandomActor(entropyTo);
 
         vm.prank(_getActor());
-        try superVault.transferFrom(from, to, value) {
-            success = true;
-        } catch (
+        try superVault.transferFrom(from, to, value) {} catch (
             bytes memory err
         ) {
+            bool expectedError;
             expectedError =
                 checkError(
                     err,
@@ -342,30 +235,6 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                     err,
                     "ERC20InsufficientAllowance(address,uint256,uint256)"
                 );
-        }
-    }
-
-    /// @dev Action: transfer shares on behalf of another actor.
-    function superVault_transferFrom(
-        uint256 entropyFrom,
-        uint256 entropyTo,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        _executeTransferFrom(entropyFrom, entropyTo, value);
-    }
-
-    /// @dev Property: _update should never revert in transferFrom unless balance/allowance is insufficient.
-    function superVault_transferFrom_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM(
-        uint256 entropyFrom,
-        uint256 entropyTo,
-        uint256 value
-    ) public updateGhostsWithOpType(OpType.TRANSFER) {
-        (bool success, bool expectedError) = _executeTransferFrom(
-            entropyFrom,
-            entropyTo,
-            value
-        );
-        if (!success) {
             t(
                 expectedError,
                 ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER_FROM


### PR DESCRIPTION
## Summary
This PR makes the recon harness compliant with `target-onboarding` naming and assertion-wrapper rules on top of `dev-recon`.

### Main changes
- Enforced `targetFunction_ASSERTION_<ASSERTION_SUFFIX>` handler naming across inherited recon targets.
- Enforced Foundry wrapper naming: `invariant_assertion_failure_<handlerIdentifier>`.
- Split multi-assert handlers so each `ASSERTION_*` reason has its own dedicated handler + wrapper.
- Preserved action handlers separately where needed so assertions stay wrapper-compatible.
- Kept assertion reason centralization in `test/recon/Properties.sol` with `!!!` prefixing.

### Files updated
- `test/recon/Properties.sol`
- `test/recon/CryticToFoundry.sol`
- `test/recon/targets/AdminTargets.sol`
- `test/recon/targets/DoomsdayTargets.sol`
- `test/recon/targets/SuperVaultTargets.sol`

## Validation
### Static compliance
- No parameterized `invariant_*` functions in `test/recon`.
- No active `property_` / `crytic_` function definitions.
- Assertion canary + global invariant canary present.
- `foundry.toml [invariant]` settings match benchmark defaults.

### Foundry compile/list
- `forge test --match-contract CryticToFoundry --list` ✅

### Canary checks
- Foundry canary invariant check (`invariant_canary`) fails as expected with `Canary invariant` ✅
- Foundry assertion canary wrapper check (`invariant_assertion_failure_assert_canary_ASSERTION_CANARY`) fails as expected with `!!! canary assertion` ✅
- Echidna 5m run reports both:
  - `invariant_canary` falsified
  - `assert_canary_ASSERTION_CANARY(uint256)` falsified ✅
- Medusa 5m run reports both:
  - `[FAILED] Property Test: CryticTester.invariant_canary()`
  - `[FAILED] Assertion Test: CryticTester.assert_canary_ASSERTION_CANARY(uint256)` with `!!! canary assertion` ✅

### Normalized overlap check from scfuzzbench PR #97
Using merged logic from `Recon-Fuzz/scfuzzbench` PR #97 (`analysis/invariant_overlap_report.py`), on captured Echidna/Medusa logs plus Foundry canary events:
- Output canonicalized assertion IDs to `assert_canary` across Echidna/Medusa/Foundry.
- Output also aligned `invariant_canary` across all three fuzzers.

Produced artifact sample (`broken_invariants.csv`) contained:
- `assert_canary` with fuzzers `echidna,foundry,medusa`
- `invariant_canary` with fuzzers `echidna,foundry,medusa`

