### PR TITLE
test(recon): normalize to one assertion constant per handler

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -112,30 +112,6 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         assertTrue(!assertionFailures[reason], reason);
     }
 
-    function invariant_assertion_failure_doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT()
-        public
-        returns (bool)
-    {
-        assertTrue(
-            !assertionFailures[ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT],
-            ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT
-        );
-        return true;
-    }
-
-    function invariant_assertion_failure_doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT()
-        public
-        returns (bool)
-    {
-        assertTrue(
-            !assertionFailures[
-                ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT
-            ],
-            ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT
-        );
-        return true;
-    }
-
     function invariant_assertion_failure_doomsday_primaryManagerAlwaysChangeable_ASSERTION_PRIMARY_MANAGER_ALWAYS_CHANGEABLE()
         public
         returns (bool)
@@ -167,17 +143,6 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
                 ASSERTION_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM
             ],
             ASSERTION_REDEEM_SHOULD_NOT_REVERT_INVALID_REDEEM_CLAIM
-        );
-        return true;
-    }
-
-    function invariant_assertion_failure_superVault_transfer_ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER()
-        public
-        returns (bool)
-    {
-        assertTrue(
-            !assertionFailures[ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER],
-            ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER
         );
         return true;
     }
@@ -257,22 +222,6 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         return true;
     }
 
-    function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
-        public
-        returns (bool)
-    {
-        _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO);
-        return true;
-    }
-
-    function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO()
-        public
-        returns (bool)
-    {
-        _assertNoAssertionFailure(ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO);
-        return true;
-    }
-
     function invariant_assertion_failure_superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY()
         public
         returns (bool)
@@ -305,14 +254,6 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         return true;
     }
 
-    function invariant_assertion_failure_superVault_transfer_ASSERTION_TRANSFER_COST_BASIS_CONSERVED()
-        public
-        returns (bool)
-    {
-        _assertNoAssertionFailure(ASSERTION_TRANSFER_COST_BASIS_CONSERVED);
-        return true;
-    }
-
     function invariant_assertion_failure_superVaultStrategy_fulfillRedeemRequests_ASSERTION_STRATEGY_NO_LOSS_ON_FULFILLMENT()
         public
         returns (bool)
@@ -329,22 +270,12 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         return true;
     }
 
-    function invariant_assertion_failure_global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS()
+    function invariant_assertion_failure_global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS()
         public
         returns (bool)
     {
         _assertNoAssertionFailure(
-            ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
-        );
-        return true;
-    }
-
-    function invariant_assertion_failure_global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS()
-        public
-        returns (bool)
-    {
-        _assertNoAssertionFailure(
-            ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS
+            ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS
         );
         return true;
     }

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -64,10 +64,8 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         "!!! strategy incurs loss on fulfillment";
     string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_SHARES =
         "!!! previewMint and previewDeposit equivalence (from shares)";
-    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS =
-        "!!! previewMint and previewDeposit equivalence under (from assets)";
-    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS =
-        "!!! previewMint and previewDeposit equivalence over (from assets)";
+    string constant ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS =
+        "!!! previewMint and previewDeposit equivalence (from assets)";
     string constant ASSERTION_GLOBAL_PREVIEW_MINT_GTE_CONVERT_TO_ASSETS =
         "!!! previewMint is >= convertToAssets";
     string constant ASSERTION_GLOBAL_CONVERT_TO_SHARES_GTE_PREVIEW_DEPOSIT =
@@ -329,7 +327,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property: previewMint and previewDeposit equivalence (from assets)
-    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS(uint256 assets) public {
+    function global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS(uint256 assets) public {
         uint256 previewDepositShares = superVault.previewDeposit(assets);
         uint256 previewMintAssets_under = superVault.previewMint(
             previewDepositShares
@@ -343,13 +341,13 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
             gte(
                 assets,
                 previewMintAssets_under,
-                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_UNDER_FROM_ASSETS
+                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS
             );
 
             lte(
                 assets,
                 previewMintAssets_over,
-                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_OVER_FROM_ASSETS
+                ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS
             );
         }
     }

--- a/test/recon/targets/DoomsdayTargets.sol
+++ b/test/recon/targets/DoomsdayTargets.sol
@@ -204,7 +204,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
             );
         } catch {
             if (maxRedeemBeforeClaim > 0) {
-                t(false, ASSERTION_REDEEM_MAX_REDEEM_SHOULD_NOT_REVERT);
+                t(false, ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION);
             }
         }
     }
@@ -243,7 +243,7 @@ abstract contract DoomsdayTargets is BaseTargetFunctions, Properties {
                 ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL
             );
         } catch {
-            t(false, ASSERTION_WITHDRAW_MAX_WITHDRAW_SHOULD_NOT_REVERT);
+            t(false, ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL);
         }
     }
 

--- a/test/recon/targets/SuperVaultTargets.sol
+++ b/test/recon/targets/SuperVaultTargets.sol
@@ -50,7 +50,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
     /// @dev Property: pendingRedeemRequest should be 0 after a user calls cancelRedeem
     /// @dev Property: averageRequestPPS should be 0 after a user calls cancelRedeem
     /// @dev Property: user shouldn't receive more than convertToAssets(pendingRedeemRequest) after cancelRedeem
-    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO()
+    function superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY()
         public
         updateGhostsWithOpType(OpType.CANCEL)
     {
@@ -83,12 +83,12 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
         eq(
             pendingRedeemRequestsAfter,
             0,
-            ASSERTION_CANCEL_REDEEM_PENDING_REQUEST_ZERO
+            ASSERTION_CANCEL_REDEEM_NO_OVERPAY
         );
         eq(
             averageRequestPPS,
             0,
-            ASSERTION_CANCEL_REDEEM_AVG_REQUEST_PPS_ZERO
+            ASSERTION_CANCEL_REDEEM_NO_OVERPAY
         );
         lte(
             balanceAfter - balanceBefore,
@@ -199,7 +199,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                     stateSenderAfter.accumulatorCostBasis,
                 stateRecipientAfter.accumulatorCostBasis -
                     stateRecipientBefore.accumulatorCostBasis,
-                ASSERTION_TRANSFER_COST_BASIS_CONSERVED
+                ASSERTION_TRANSFER_SHARES_CONSERVED
             );
         } catch (bytes memory err) {
             bool expectedError;
@@ -207,7 +207,7 @@ abstract contract SuperVaultTargets is BaseTargetFunctions, Properties {
                 err,
                 "ERC20InsufficientBalance(address,uint256,uint256)"
             );
-            t(expectedError, ASSERTION_UPDATE_SHOULD_NOT_REVERT_TRANSFER);
+            t(expectedError, ASSERTION_TRANSFER_SHARES_CONSERVED);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep original target-function bodies and control flow intact
- reconcile multi-constant handlers by reusing a single assertion constant inside each affected function
- rename only where needed for function/constant alignment

Applied under `test/recon/`:
- `global_previewEquivalenceFromAssets_ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS`
  - both `gte` and `lte` now use `ASSERTION_GLOBAL_PREVIEW_EQUIVALENCE_FROM_ASSETS`
- `superVault_cancelRedeem_ASSERTION_CANCEL_REDEEM_NO_OVERPAY`
  - existing checks kept; all three now use `ASSERTION_CANCEL_REDEEM_NO_OVERPAY`
- `superVault_transfer_ASSERTION_TRANSFER_SHARES_CONSERVED`
  - existing checks kept; all checks now use `ASSERTION_TRANSFER_SHARES_CONSERVED`
- `doomsday_maxRedeemResetsAfterFullRedemption_ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION`
  - catch path now also uses `ASSERTION_MAX_REDEEM_RESETS_AFTER_FULL_REDEMPTION`
- `doomsday_maxWithdrawResetsAfterFullWithdrawal_ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL`
  - catch path now also uses `ASSERTION_MAX_WITHDRAW_RESETS_AFTER_FULL_WITHDRAWAL`

`CryticToFoundry` wrappers were trimmed to keep one wrapper per final handler identifier.

## Validation
- static audit confirms every `*_ASSERTION_*` function under `test/recon/` references exactly one `ASSERTION_*` constant
- local forge listing remains blocked in this worktree due missing libs/submodules (`lib/v2-core`, `lib/setup-helpers`, `lib/forge-std`)
