### PR TITLE
Removed bytecode_hash = "none"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,6 @@
 [profile.default]
 cache_path = "cache"
 auto_detect_solc = false
-bytecode_hash = "none"
 fuzz = { runs = 10 }
 gas_reports = ["*"]
 optimizer = true


### PR DESCRIPTION
Remove hashes from bytecode metadata will cause high memory consumption and degraded performance in some fuzzing tools.