### PR TITLE
Disable use of properties in medusa

### DIFF
--- a/medusa.json
+++ b/medusa.json
@@ -50,7 +50,7 @@
         }
       },
       "propertyTesting": {
-        "enabled": true,
+        "enabled": false,
         "testPrefixes": [
           "invariant_"
         ]


### PR DESCRIPTION
Per #12, the `crytic_` functions are really assertion checking not properties (they can safely revert without indicating an issue).