### PR TITLE
Issue #12: keep Medusa properties enabled, fix ERC7540 stateless mismatch

### DIFF
--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -725,7 +725,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     // ERC7540 Properties from erc7540-reusable-properties
 
     /// @dev Property 7540-1: convertToAssets(totalSupply) == totalAssets unless price is 0.0
-    function invariant_erc7540_1() public stateless returns (bool) {
+    function invariant_erc7540_1() public returns (bool) {
         actor = _getActor();
         t(
             erc7540_1(address(superVault)),
@@ -735,7 +735,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-2: convertToShares(totalAssets) == totalSupply unless price is 0.0
-    function invariant_erc7540_2() public stateless returns (bool) {
+    function invariant_erc7540_2() public returns (bool) {
         actor = _getActor();
         t(
             erc7540_2(address(superVault)),
@@ -745,7 +745,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-3: max* never reverts
-    function invariant_erc7540_3() public stateless returns (bool) {
+    function invariant_erc7540_3() public returns (bool) {
         actor = _getActor();
         t(
             erc7540_3(address(superVault)),
@@ -755,7 +755,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-4: claiming more than max always reverts
-    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(uint256 amt) public stateless {
+    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(uint256 amt) public {
         actor = _getActor();
         t(
             erc7540_4_deposit(address(superVault), amt),
@@ -763,7 +763,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(uint256 amt) public stateless {
+    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(uint256 amt) public {
         actor = _getActor();
         t(
             erc7540_4_mint(address(superVault), amt),
@@ -771,7 +771,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(uint256 amt) public stateless {
+    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(uint256 amt) public {
         actor = _getActor();
         t(
             erc7540_4_withdraw(address(superVault), amt),
@@ -779,7 +779,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(uint256 amt) public stateless {
+    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(uint256 amt) public {
         actor = _getActor();
         t(
             erc7540_4_redeem(address(superVault), amt),
@@ -788,7 +788,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-5: requestRedeem reverts if the share balance is less than amount
-    function global_erc7540_5_ASSERTION_ERC7540_5(uint256 shares) public stateless {
+    function global_erc7540_5_ASSERTION_ERC7540_5(uint256 shares) public {
         actor = _getActor();
         t(
             erc7540_5(address(superVault), address(superVault), shares),
@@ -825,7 +825,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     //     );
     // }
 
-    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(uint256 amt) public stateless {
+    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(uint256 amt) public {
         actor = _getActor();
         t(
             erc7540_7_withdraw(address(superVault), amt),
@@ -834,7 +834,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     // NOTE: this implements the check from ERC7540Properties directly because SuperVault logic implementation allows amt to be nonzero but round down to 0 when assets passed into redeem are calculated
-    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(uint256 amt) public stateless {
+    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(uint256 amt) public {
         actor = _getActor();
 
         uint256 maxRedeem = superVault.maxRedeem(actor);

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -755,7 +755,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-4: claiming more than max always reverts
-    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(uint256 amt) public {
+    function global_erc7540_4_deposit_ASSERTION_ERC7540_4_DEPOSIT(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_deposit(address(superVault), amt),
@@ -763,7 +763,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(uint256 amt) public {
+    function global_erc7540_4_mint_ASSERTION_ERC7540_4_MINT(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_mint(address(superVault), amt),
@@ -771,7 +771,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(uint256 amt) public {
+    function global_erc7540_4_withdraw_ASSERTION_ERC7540_4_WITHDRAW(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_withdraw(address(superVault), amt),
@@ -779,7 +779,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
         );
     }
 
-    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(uint256 amt) public {
+    function global_erc7540_4_redeem_ASSERTION_ERC7540_4_REDEEM(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_4_redeem(address(superVault), amt),
@@ -788,7 +788,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     /// @dev Property 7540-5: requestRedeem reverts if the share balance is less than amount
-    function global_erc7540_5_ASSERTION_ERC7540_5(uint256 shares) public {
+    function global_erc7540_5_ASSERTION_ERC7540_5(uint256 shares) public stateless {
         actor = _getActor();
         t(
             erc7540_5(address(superVault), address(superVault), shares),
@@ -825,7 +825,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     //     );
     // }
 
-    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(uint256 amt) public {
+    function global_erc7540_7_withdraw_ASSERTION_ERC7540_7_WITHDRAW(uint256 amt) public stateless {
         actor = _getActor();
         t(
             erc7540_7_withdraw(address(superVault), amt),
@@ -834,7 +834,7 @@ abstract contract Properties is BeforeAfter, Asserts, ERC7540Properties {
     }
 
     // NOTE: this implements the check from ERC7540Properties directly because SuperVault logic implementation allows amt to be nonzero but round down to 0 when assets passed into redeem are calculated
-    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(uint256 amt) public {
+    function global_erc7540_7_redeem_ASSERTION_ERC7540_7_REDEEM(uint256 amt) public stateless {
         actor = _getActor();
 
         uint256 maxRedeem = superVault.maxRedeem(actor);


### PR DESCRIPTION
## Summary
This addresses #12 without disabling Medusa property testing globally.

I evaluated #14 (`Disable use of properties in medusa`) and do **not** think it is the best fix because it disables all `invariant_` property checks for Medusa.

## Assessment of #14
`#14` changes only:
- `medusa.json`: `propertyTesting.enabled: true -> false`

Why this is problematic:
1. It removes Medusa coverage for global invariants entirely (including `invariant_canary`).
2. It conflicts with `scfuzzbench` onboarding guidance in `skills/target-onboarding/SKILL.md`:
   - Medusa section says property prefix should stay `invariant_` and Medusa can run assertion + property testing together.
   - Validation/acceptance gate expects each fuzzer to catch both canaries, including the global invariant canary.
3. It treats the symptom (disable properties) instead of the source issue (these specific invariant functions being `stateless`).

## Recon Book finding (`stateless` intent)
Reference: https://book.getrecon.xyz/writing_invariant_tests/example_project.html#checking-for-overflow

That section uses `stateless` for doomsday/assertion handlers to avoid preserving side effects while testing a specific behavior. This supports keeping `global_*` handlers stateless.

Key distinction for this issue:
- `global_*` with args: can remain `stateless` (intentional doomsday/assertion pattern)
- `invariant_*` Medusa property tests: should not be `stateless`, because they terminate with `revert("stateless")` and are invalid as properties

## What this PR changes
- Keeps Medusa property testing enabled.
- Removes `stateless` only from:
  - `invariant_erc7540_1`
  - `invariant_erc7540_2`
  - `invariant_erc7540_3`

These are Medusa property tests (`invariant_` prefix). With `stateless`, they always end in `revert("stateless")`, which makes them invalid property checks.

`global_*` assertion handlers remain `stateless` per Recon book intent (no side effects preserved for those doomsday/global checks).

## Validation
- `forge test --match-contract CryticToFoundry --list` passes (compile successful).
- Medusa smoke comparison:
  - On #14: startup shows only `Assertion Test:` entries and no `Property Test:` / `invariant_canary` coverage.
  - On this branch: startup includes `Property Test:` entries, including `invariant_canary` and `invariant_erc7540_{1,2,3}`.